### PR TITLE
Support users that aren't allowed to administer their own accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ policies to them.  We recommend creating your Users account via the
 |------|-------------|------|---------|:--------:|
 | aws_region | The AWS region where the non-global resources are to be provisioned (e.g. "us-east-1"). | `string` | `us-east-1` | no |
 | tags | Tags to apply to all AWS resources created | `map(string)` | `{}` | no |
-| users | A list containing the usernames of each non-admin user.  Example: [ "firstname1.lastname1", "firstname2.lastname2", "firstname3.lastname3" ] | `list` | n/a | yes |
+| users | A list containing the usernames of each non-admin user.  Example: [ "firstname1.lastname1", "firstname2.lastname2", "firstname3.lastname3" ] | `list(string)` | n/a | yes |
 
 ## Outputs ##
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ policies to them.  We recommend creating your Users account via the
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | aws_region | The AWS region where the non-global resources are to be provisioned (e.g. "us-east-1"). | `string` | `us-east-1` | no |
+| non_self_admin_users | A list containing the usernames of non-admin users that are not allowed to administer their own accounts.  Example: [ "service-account1", "service-account2", "service-account3" ] | `list(string)` | `[]` | no |
 | tags | Tags to apply to all AWS resources created | `map(string)` | `{}` | no |
 | users | A list containing the usernames of each non-admin user.  Example: [ "firstname1.lastname1", "firstname2.lastname2", "firstname3.lastname3" ] | `list(string)` | n/a | yes |
 

--- a/users.tf
+++ b/users.tf
@@ -2,7 +2,7 @@
 resource "aws_iam_user" "users" {
   provider = aws.users
 
-  for_each = toset(var.users)
+  for_each = toset(concat(var.users, var.non_self_admin_users))
 
   name = each.key
   tags = var.tags

--- a/variables.tf
+++ b/variables.tf
@@ -17,6 +17,7 @@ variable "users" {
 # ------------------------------------------------------------------------------
 
 variable "aws_region" {
+  type        = string
   description = "The AWS region where the non-global resources are to be provisioned (e.g. \"us-east-1\")."
   default     = "us-east-1"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -5,9 +5,9 @@
 # ------------------------------------------------------------------------------
 
 variable "users" {
+  type = list(string)
   # Currently-defined roles: financial_audit, security_audit
   description = "A list containing the usernames of each non-admin user.  Example: [ \"firstname1.lastname1\", \"firstname2.lastname2\", \"firstname3.lastname3\" ]"
-  type        = list
 }
 
 # ------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,12 @@ variable "aws_region" {
   default     = "us-east-1"
 }
 
+variable "non_self_admin_users" {
+  type        = list(string)
+  description = "A list containing the usernames of non-admin users that are not allowed to administer their own accounts.  Example: [ \"service-account1\", \"service-account2\", \"service-account3\" ]"
+  default     = []
+}
+
 variable "tags" {
   type        = map(string)
   description = "Tags to apply to all AWS resources created"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
This PR adds the ability to create users that aren't allowed to administer their own accounts.  

There are also some minor changes to clean up some variable type declarations (https://github.com/cisagov/cool-users-non-admin/commit/d32ffcfed0d0abd0da815f59056b2d93b0f7f258 and https://github.com/cisagov/cool-users-non-admin/commit/fe84f95255626619c5d58c1e469451e7bc1e5988).

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
This feature originated in [`cisagov/cool-users-pca`](https://github.com/cisagov/cool-users-pca).  Now that we are consolidating all account creation in this repository, we must add that feature here.

This PR is part of the work needed for https://github.com/cisagov/cool-system/issues/114.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
First, I updated my tfvars file to include the usernames of the three users created in [`cisagov/cool-users-pca`](https://github.com/cisagov/cool-users-pca).  One of the users was placed in the list of `non_self_admin_users`, to match how it had previously been set up in `cisagov/cool-users-pca`.

Then, I used `terraform import` to import the three PCA users and their corresponding user policies (for the two users that had them) into the Terraform state for this repository, e.g.:
```
terraform import 'aws_iam_user.users["firstname.lastname"]' firstname.lastname
terraform import 'aws_iam_user_policy.self_managed_creds_with_mfa["firstname.lastname"]' firstname.lastname:SelfManagedCredsWithMFA
```

Finally, I ran a `terraform apply` and confirmed that no changes (other than one tag, which was expected) were needed.

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
