### PR TITLE
Use external policies to self-manage credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ policies to them.  We recommend creating your Users account via the
 | aws_region | The AWS region where the non-global resources are to be provisioned (e.g. "us-east-1"). | `string` | `us-east-1` | no |
 | non_self_admin_users | A list containing the usernames of non-admin users that are not allowed to administer their own accounts.  Example: [ "service-account1", "service-account2", "service-account3" ] | `list(string)` | `[]` | no |
 | tags | Tags to apply to all AWS resources created | `map(string)` | `{}` | no |
-| users | A list containing the usernames of each non-admin user.  Example: [ "firstname1.lastname1", "firstname2.lastname2", "firstname3.lastname3" ] | `list(string)` | n/a | yes |
+| users | A map whose keys are the usernames of each non-admin user and whose values are a map containing supported user attribtes.  The only currently-supported attribute is "require_mfa" (boolean).  Example: { "firstname1.lastname1" = { "require_mfa" = false }, "firstname2.lastname2" = { "require_mfa" = true }, "firstname3.lastname3" = { "require_mfa" = false } } | `map(map(string))` | n/a | yes |
 
 ## Outputs ##
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ policies to them.  We recommend creating your Users account via the
 | aws_region | The AWS region where the non-global resources are to be provisioned (e.g. "us-east-1"). | `string` | `us-east-1` | no |
 | non_self_admin_users | A list containing the usernames of non-admin users that are not allowed to administer their own accounts.  Example: [ "service-account1", "service-account2", "service-account3" ] | `list(string)` | `[]` | no |
 | tags | Tags to apply to all AWS resources created | `map(string)` | `{}` | no |
-| users | A map whose keys are the usernames of each non-admin user and whose values are a map containing supported user attribtes.  The only currently-supported attribute is "require_mfa" (boolean).  Example: { "firstname1.lastname1" = { "require_mfa" = false }, "firstname2.lastname2" = { "require_mfa" = true }, "firstname3.lastname3" = { "require_mfa" = false } } | `map(map(string))` | n/a | yes |
+| users | A map whose keys are the usernames of each non-admin user and whose values are a map containing supported user attributes.  The only currently-supported attribute is "require_mfa" (boolean).  Example: { "firstname1.lastname1" = { "require_mfa" = false }, "firstname2.lastname2" = { "require_mfa" = true }, "firstname3.lastname3" = { "require_mfa" = false } } | `map(map(string))` | n/a | yes |
 
 ## Outputs ##
 

--- a/users.tf
+++ b/users.tf
@@ -2,182 +2,30 @@
 resource "aws_iam_user" "users" {
   provider = aws.users
 
-  for_each = toset(concat(var.users, var.non_self_admin_users))
+  for_each = toset(concat(keys(var.users), var.non_self_admin_users))
 
   name = each.key
   tags = var.tags
 }
 
-# IAM policy that allows users to administer their own user
-# accounts.  This policy is pretty much copied from here:
-# https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage.html
-data "aws_iam_policy_document" "iam_self_admin_doc" {
-  for_each = toset(var.users)
-
-  # Allow users to view their own account information
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "iam:GetAccountPasswordPolicy",
-      "iam:GetAccountSummary",
-      "iam:ListVirtualMFADevices",
-    ]
-
-    resources = [
-      "*",
-    ]
-  }
-
-  # Allow users to administer their own passwords
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "iam:ChangePassword",
-      "iam:GetUser",
-    ]
-
-    resources = [
-      aws_iam_user.users[each.key].arn,
-    ]
-  }
-
-  # Allow users to administer their own access keys
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "iam:CreateAccessKey",
-      "iam:DeleteAccessKey",
-      "iam:ListAccessKeys",
-      "iam:UpdateAccessKey",
-    ]
-
-    resources = [
-      aws_iam_user.users[each.key].arn,
-    ]
-  }
-
-  # Allow users to administer their own signing certificates
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "iam:DeleteSigningCertificate",
-      "iam:ListSigningCertificates",
-      "iam:UpdateSigningCertificate",
-      "iam:UploadSigningCertificate",
-    ]
-
-    resources = [
-      aws_iam_user.users[each.key].arn,
-    ]
-  }
-
-  # Allow users to administer their own ssh public keys
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "iam:DeleteSSHPublicKey",
-      "iam:GetSSHPublicKey",
-      "iam:ListSSHPublicKeys",
-      "iam:UpdateSSHPublicKey",
-      "iam:UploadSSHPublicKey",
-    ]
-
-    resources = [
-      aws_iam_user.users[each.key].arn,
-    ]
-  }
-
-  # Allow users to administer their own git credentials
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "iam:CreateServiceSpecificCredential",
-      "iam:DeleteServiceSpecificCredential",
-      "iam:ListServiceSpecificCredentials",
-      "iam:ResetServiceSpecificCredential",
-      "iam:UpdateServiceSpecificCredential",
-    ]
-
-    resources = [
-      aws_iam_user.users[each.key].arn,
-    ]
-  }
-
-  # Allow users to administer their own virtual MFA device
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "iam:CreateVirtualMFADevice",
-      "iam:DeleteVirtualMFADevice",
-    ]
-
-    resources = [
-      # The MFA ARN is identical to that of the user, except that the
-      # text "user" is replaced by "mfa"
-      replace(aws_iam_user.users[each.key].arn, "user", "mfa"),
-    ]
-  }
-
-  # Allow users to administer their own (non-virtual) MFA device
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "iam:DeactivateMFADevice",
-      "iam:EnableMFADevice",
-      "iam:ListMFADevices",
-      "iam:ResyncMFADevice",
-    ]
-
-    resources = [
-      aws_iam_user.users[each.key].arn,
-    ]
-  }
-
-  # Deny all actions but the following if no MFA device is configured
-  statement {
-    effect = "Deny"
-
-    not_actions = [
-      "iam:ChangePassword",
-      "iam:CreateVirtualMFADevice",
-      "iam:EnableMFADevice",
-      "iam:GetUser",
-      "iam:ListMFADevices",
-      "iam:ListVirtualMFADevices",
-      "iam:ResyncMFADevice",
-      "sts:GetSessionToken",
-    ]
-
-    resources = [
-      "*",
-    ]
-
-    condition {
-      test     = "BoolIfExists"
-      variable = "aws:MultiFactorAuthPresent"
-
-      values = [
-        false,
-      ]
-    }
-  }
-}
-
-# The IAM self-administration policy for our IAM users
-resource "aws_iam_user_policy" "self_managed_creds_with_mfa" {
+# Attach the self-administration (with MFA required) policy to each user
+# where require_mfa is true
+resource "aws_iam_user_policy_attachment" "self_managed_creds_with_mfa" {
   provider = aws.users
 
-  for_each = toset(var.users)
+  for_each = { for k, v in var.users : k => v if v["require_mfa"] }
 
-  name   = "SelfManagedCredsWithMFA"
-  user   = each.key
-  policy = data.aws_iam_policy_document.iam_self_admin_doc[each.key].json
+  user       = each.key
+  policy_arn = data.terraform_remote_state.users.outputs.selfmanagedcredswithmfa_policy.arn
+}
+
+# Attach the self-administration (without MFA required) policy to each user
+# where require_mfa is false
+resource "aws_iam_user_policy_attachment" "self_managed_creds_without_mfa" {
+  provider = aws.users
+
+  for_each = { for k, v in var.users : k => v if ! v["require_mfa"] }
+
+  user       = each.key
+  policy_arn = data.terraform_remote_state.users.outputs.selfmanagedcredswithoutmfa_policy.arn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,7 +6,7 @@
 
 variable "users" {
   type        = map(map(string))
-  description = "A map whose keys are the usernames of each non-admin user and whose values are a map containing supported user attribtes.  The only currently-supported attribute is \"require_mfa\" (boolean).  Example: { \"firstname1.lastname1\" = { \"require_mfa\" = false }, \"firstname2.lastname2\" = { \"require_mfa\" = true }, \"firstname3.lastname3\" = { \"require_mfa\" = false } }"
+  description = "A map whose keys are the usernames of each non-admin user and whose values are a map containing supported user attributes.  The only currently-supported attribute is \"require_mfa\" (boolean).  Example: { \"firstname1.lastname1\" = { \"require_mfa\" = false }, \"firstname2.lastname2\" = { \"require_mfa\" = true }, \"firstname3.lastname3\" = { \"require_mfa\" = false } }"
 }
 
 # ------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -5,9 +5,8 @@
 # ------------------------------------------------------------------------------
 
 variable "users" {
-  type = list(string)
-  # Currently-defined roles: financial_audit, security_audit
-  description = "A list containing the usernames of each non-admin user.  Example: [ \"firstname1.lastname1\", \"firstname2.lastname2\", \"firstname3.lastname3\" ]"
+  type        = map(map(string))
+  description = "A map whose keys are the usernames of each non-admin user and whose values are a map containing supported user attribtes.  The only currently-supported attribute is \"require_mfa\" (boolean).  Example: { \"firstname1.lastname1\" = { \"require_mfa\" = false }, \"firstname2.lastname2\" = { \"require_mfa\" = true }, \"firstname3.lastname3\" = { \"require_mfa\" = false } }"
 }
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds support for creating non-admin users that may or may not be required to use multi-factor authentication (MFA).  It removes the inline policy (`SelfManagedCredsWithMFA`) and replaces it with one of the policies created in https://github.com/cisagov/cool-accounts/pull/79.
 
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Previously, all non-admin users were required to use MFA.  However, certain non-admin users require programmatic access to IAM roles, so those users can now be given the appropriate IAM policy to allow that.

This PR is dependent on the changes in https://github.com/cisagov/cool-accounts/pull/79.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I applied these changes in Production and verified that each user was given the appropriate policy (either MFA-required or no MFA required).

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [x] All new and existing tests pass.
