### PR TITLE
Make policy attachments depend on users

### DIFF
--- a/users.tf
+++ b/users.tf
@@ -12,6 +12,9 @@ resource "aws_iam_user" "users" {
 resource "aws_iam_user_policy_attachment" "self_managed_creds_with_mfa" {
   provider = aws.users
 
+  # Ensure that the user exists before attempting to attach the policy
+  depends_on = [aws_iam_user.users]
+
   for_each = { for k, v in var.users : k => v if v["require_mfa"] }
 
   user       = each.key
@@ -22,6 +25,9 @@ resource "aws_iam_user_policy_attachment" "self_managed_creds_with_mfa" {
 # where require_mfa is false
 resource "aws_iam_user_policy_attachment" "self_managed_creds_without_mfa" {
   provider = aws.users
+
+  # Ensure that the user exists before attempting to attach the policy
+  depends_on = [aws_iam_user.users]
 
   for_each = { for k, v in var.users : k => v if ! v["require_mfa"] }
 

--- a/users.tf
+++ b/users.tf
@@ -12,7 +12,13 @@ resource "aws_iam_user" "users" {
 resource "aws_iam_user_policy_attachment" "self_managed_creds_with_mfa" {
   provider = aws.users
 
-  # Ensure that the user exists before attempting to attach the policy
+  # Ensure that the user exists before attempting to attach the
+  # policy.  Ideally the depends_on could live inside the scope of the
+  # for_each, so that we could depend only on the specific user that
+  # this policy attachment references, but that is not possible;
+  # hence, we must depend on _all_ users.  The effect is the same,
+  # although getting there is less efficient since _all_ the users are
+  # created before _any_ policy attachments.
   depends_on = [aws_iam_user.users]
 
   for_each = { for k, v in var.users : k => v if v["require_mfa"] }
@@ -26,7 +32,13 @@ resource "aws_iam_user_policy_attachment" "self_managed_creds_with_mfa" {
 resource "aws_iam_user_policy_attachment" "self_managed_creds_without_mfa" {
   provider = aws.users
 
-  # Ensure that the user exists before attempting to attach the policy
+  # Ensure that the user exists before attempting to attach the
+  # policy.  Ideally the depends_on could live inside the scope of the
+  # for_each, so that we could depend only on the specific user that
+  # this policy attachment references, but that is not possible;
+  # hence, we must depend on _all_ users.  The end result is the same,
+  # although getting there is less efficient since _all_ the users are
+  # created before _any_ policy attachments.
   depends_on = [aws_iam_user.users]
 
   for_each = { for k, v in var.users : k => v if ! v["require_mfa"] }


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the policy attachment resources to depend on the `aws_iam_user.users` resource.

## 💭 Motivation and context ##

Resolves #22.

## 🧪 Testing ##

I successfully applied these changes to add a new user and verified that the failure I previously observer no longer happens.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
