### PR TITLE
Combine variables that provide user information

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,8 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | aws\_region | The AWS region where the non-global resources are to be provisioned (e.g. "us-east-1"). | `string` | `"us-east-1"` | no |
-| non\_self\_admin\_users | A list containing the usernames of non-admin users that are not allowed to administer their own accounts.  Example: [ "service-account1", "service-account2", "service-account3" ] | `list(string)` | `[]` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
-| users | A map whose keys are the usernames of each non-admin user and whose values are a map containing supported user attributes.  The only currently-supported attribute is "require\_mfa" (boolean).  Example: { "firstname1.lastname1" = { "require\_mfa" = false }, "firstname2.lastname2" = { "require\_mfa" = true }, "firstname3.lastname3" = { "require\_mfa" = false } } | `map(map(string))` | n/a | yes |
+| users | A map whose keys are the usernames of each non-admin user and whose values are a map containing supported user attributes.  The currently-supported attributes are "require\_mfa" (boolean) and "self\_managed" (boolean).  Example: { "firstname1.lastname1" = { "require\_mfa" = false, "self\_managed" = true }, "firstname2.lastname2" = { "require\_mfa" = true, "self\_managed" = true }, "firstname3.lastname3" = { "require\_mfa" = false, "self\_managed" = true }, "service-account1" = { "require\_mfa" = false, "self\_managed" = false } } | `map(map(string))` | n/a | yes |
 
 ## Outputs ##
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | aws\_region | The AWS region where the non-global resources are to be provisioned (e.g. "us-east-1"). | `string` | `"us-east-1"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
-| users | A map whose keys are the usernames of each non-admin user and whose values are a map containing supported user attributes.  The currently-supported attributes are "require\_mfa" (boolean) and "self\_managed" (boolean).  Example: { "firstname1.lastname1" = { "require\_mfa" = false, "self\_managed" = true }, "firstname2.lastname2" = { "require\_mfa" = true, "self\_managed" = true }, "firstname3.lastname3" = { "require\_mfa" = false, "self\_managed" = true }, "service-account1" = { "require\_mfa" = false, "self\_managed" = false } } | `map(map(string))` | n/a | yes |
+| users | A map whose keys are the usernames of each non-admin user and whose values are a map containing supported user attributes.  The currently-supported attributes are "require\_mfa" (boolean) and "self\_managed" (boolean).  Example: { "firstname1.lastname1" = { "require\_mfa" = false, "self\_managed" = true }, "firstname2.lastname2" = { "require\_mfa" = true, "self\_managed" = true }, "firstname3.lastname3" = { "require\_mfa" = false, "self\_managed" = true }, "service-account1" = { "require\_mfa" = false, "self\_managed" = false } } | `map(object({ require_mfa = bool, self_managed = bool }))` | n/a | yes |
 
 ## Outputs ##
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ policies to them.  We recommend creating your Users account via the
    variables (see [Inputs](#Inputs) below for details):
 
    ```hcl
-   users = [
-     "firstname1.lastname1",
-     "firstname2.lastname2",
-     "firstname3.lastname3",
-   ]
+   users = {
+     "firstname1.lastname1" = { "require_mfa" = false, "self_managed" = true },
+     "firstname2.lastname2" = { "require_mfa" = true, "self_managed" = true },
+     "firstname3.lastname3" = { "require_mfa" = false, "self_managed" = true },
+     "service-account1"     = { "require_mfa" = false, "self_managed" = false },
+   }
    ```
 
 1. Run the command `terraform init`.

--- a/users.tf
+++ b/users.tf
@@ -8,7 +8,7 @@ resource "aws_iam_user" "users" {
 }
 
 # Attach the self-administration (with MFA required) policy to each user
-# where require_mfa is true
+# where self_managed is true and require_mfa is true
 resource "aws_iam_user_policy_attachment" "self_managed_creds_with_mfa" {
   provider = aws.users
 
@@ -28,7 +28,7 @@ resource "aws_iam_user_policy_attachment" "self_managed_creds_with_mfa" {
 }
 
 # Attach the self-administration (without MFA required) policy to each user
-# where require_mfa is false
+# where self_managed is true and require_mfa is false
 resource "aws_iam_user_policy_attachment" "self_managed_creds_without_mfa" {
   provider = aws.users
 

--- a/users.tf
+++ b/users.tf
@@ -2,7 +2,7 @@
 resource "aws_iam_user" "users" {
   provider = aws.users
 
-  for_each = toset(concat(keys(var.users), var.non_self_admin_users))
+  for_each = toset(keys(var.users))
 
   name = each.key
 }
@@ -21,7 +21,7 @@ resource "aws_iam_user_policy_attachment" "self_managed_creds_with_mfa" {
   # created before _any_ policy attachments.
   depends_on = [aws_iam_user.users]
 
-  for_each = { for k, v in var.users : k => v if v["require_mfa"] }
+  for_each = { for k, v in var.users : k => v if v["self_managed"] && v["require_mfa"] }
 
   user       = each.key
   policy_arn = data.terraform_remote_state.users.outputs.selfmanagedcredswithmfa_policy.arn
@@ -41,7 +41,7 @@ resource "aws_iam_user_policy_attachment" "self_managed_creds_without_mfa" {
   # created before _any_ policy attachments.
   depends_on = [aws_iam_user.users]
 
-  for_each = { for k, v in var.users : k => v if !v["require_mfa"] }
+  for_each = { for k, v in var.users : k => v if v["self_managed"] && !v["require_mfa"] }
 
   user       = each.key
   policy_arn = data.terraform_remote_state.users.outputs.selfmanagedcredswithoutmfa_policy.arn

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@
 # ------------------------------------------------------------------------------
 
 variable "users" {
-  type        = map(map(string))
+  type        = map(object({ require_mfa = bool, self_managed = bool }))
   description = "A map whose keys are the usernames of each non-admin user and whose values are a map containing supported user attributes.  The currently-supported attributes are \"require_mfa\" (boolean) and \"self_managed\" (boolean).  Example: { \"firstname1.lastname1\" = { \"require_mfa\" = false, \"self_managed\" = true }, \"firstname2.lastname2\" = { \"require_mfa\" = true, \"self_managed\" = true }, \"firstname3.lastname3\" = { \"require_mfa\" = false, \"self_managed\" = true }, \"service-account1\" = { \"require_mfa\" = false, \"self_managed\" = false } }"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -6,7 +6,7 @@
 
 variable "users" {
   type        = map(map(string))
-  description = "A map whose keys are the usernames of each non-admin user and whose values are a map containing supported user attributes.  The only currently-supported attribute is \"require_mfa\" (boolean).  Example: { \"firstname1.lastname1\" = { \"require_mfa\" = false }, \"firstname2.lastname2\" = { \"require_mfa\" = true }, \"firstname3.lastname3\" = { \"require_mfa\" = false } }"
+  description = "A map whose keys are the usernames of each non-admin user and whose values are a map containing supported user attributes.  The currently-supported attributes are \"require_mfa\" (boolean) and \"self_managed\" (boolean).  Example: { \"firstname1.lastname1\" = { \"require_mfa\" = false, \"self_managed\" = true }, \"firstname2.lastname2\" = { \"require_mfa\" = true, \"self_managed\" = true }, \"firstname3.lastname3\" = { \"require_mfa\" = false, \"self_managed\" = true }, \"service-account1\" = { \"require_mfa\" = false, \"self_managed\" = false } }"
 }
 
 # ------------------------------------------------------------------------------
@@ -19,12 +19,6 @@ variable "aws_region" {
   type        = string
   description = "The AWS region where the non-global resources are to be provisioned (e.g. \"us-east-1\")."
   default     = "us-east-1"
-}
-
-variable "non_self_admin_users" {
-  type        = list(string)
-  description = "A list containing the usernames of non-admin users that are not allowed to administer their own accounts.  Example: [ \"service-account1\", \"service-account2\", \"service-account3\" ]"
-  default     = []
 }
 
 variable "tags" {


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request is mainly about removing the `non_self_admin_users` variable and expanding the `users` variable to include the same functionality. It also updates the `type` constraint for the `users` variable to reference the supported attributes. Lastly it updates the tfvars example in the README to mirror what is given in the example for the `users` variable.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This idea was mentioned by @jsf9k in https://github.com/cisagov/cyhy-users-non-admin/pull/5#discussion_r819646945 and was met with team agreement. Thus I am implementing it in this pull request.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I updated the Production environment tfvars to reflect the changes in this pull request and a `terraform plan` shows no changes for existing users.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
